### PR TITLE
handle mutable config files

### DIFF
--- a/home/common/gui/ghostty.nix
+++ b/home/common/gui/ghostty.nix
@@ -1,5 +1,9 @@
-{...}: {
-  home.file.".config/ghostty/config".text = ''
+{
+  mylib,
+  pkgs,
+  ...
+}: let
+  defaultConfig = ''
     theme = catppuccin-mocha
 
     window-inherit-working-directory = "true"
@@ -7,4 +11,12 @@
     macos-titlebar-style = "hidden"
 
   '';
+in {
+  # Copy config to create an editable file (not a symlink)
+  home.activation.copyGhosttyConfig = mylib.mkEditableConfig {
+    name = "Ghostty";
+    configPath = "$HOME/.config/ghostty/config";
+    content = defaultConfig;
+    pkgs = pkgs;
+  };
 }

--- a/home/common/gui/vscode/cursor.nix
+++ b/home/common/gui/vscode/cursor.nix
@@ -1,21 +1,17 @@
-{pkgs, ...}: let
+{
+  pkgs,
+  mylib,
+  ...
+}: let
   commonSettings = (import ./common.nix {inherit pkgs;}).commonSettings;
   settingsJson = builtins.toJSON commonSettings;
 in {
   # Copy settings to create an editable file (not a symlink)
-  home.activation.copyCursorSettings = ''
-    SETTINGS_DIR="$HOME/Library/Application Support/Cursor/User"
-    SETTINGS_FILE="$SETTINGS_DIR/settings.json"
-
-    # Create directory if it doesn't exist
-    mkdir -p "$SETTINGS_DIR"
-
-    # Format JSON with jq and copy settings as a real file (overwrites existing)
-    echo '${settingsJson}' | ${pkgs.jq}/bin/jq '.' > "$SETTINGS_FILE"
-
-    # Make sure it's writable
-    chmod 644 "$SETTINGS_FILE"
-
-    echo "Cursor settings copied to $SETTINGS_FILE (editable, formatted)"
-  '';
+  home.activation.copyCursorSettings = mylib.mkEditableConfig {
+    name = "Cursor";
+    configPath = "$HOME/Library/Application Support/Cursor/User/settings.json";
+    content = settingsJson;
+    pkgs = pkgs;
+    isJson = true;
+  };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -59,11 +59,13 @@
       else "false"
     }; then
           # For JSON: use jq to format
-          echo '${content}' | ${
+          cat <<'NIXEOF' | ${
       if pkgs != null
       then "${pkgs.jq}/bin/jq '.'"
       else "cat"
     } > "$TEMP_FILE"
+${content}
+NIXEOF
         else
           # For plain text: write content directly to avoid shell interpretation
           cat > "$TEMP_FILE" << 'NIXEOF'

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -38,13 +38,10 @@
     configFile = builtins.baseNameOf configPath;
     backupFile = "${configDir}/${configFile}.home-manager.backup";
 
-    # Escape content for safe shell usage
-    escapedContent = builtins.replaceStrings ["'"] ["'\"'\"'"] content;
-
     formatCommand =
       if isJson && pkgs != null
       then "echo '${content}' | ${pkgs.jq}/bin/jq '.'"
-      else "printf '%s' '${escapedContent}'";
+      else "cat";
 
     # Use delta if available, fallback to diff
     diffCommand =
@@ -52,35 +49,50 @@
       then "${pkgs.delta}/bin/delta --file-style=omit --hunk-header-style=omit"
       else "diff -u";
   in ''
-    CONFIG_DIR="${configDir}"
-    CONFIG_FILE="${configPath}"
-    BACKUP_FILE="${backupFile}"
+        CONFIG_DIR="${configDir}"
+        CONFIG_FILE="${configPath}"
+        BACKUP_FILE="${backupFile}"
 
-    # Create directory if it doesn't exist
-    mkdir -p "$CONFIG_DIR"
+        # Create directory if it doesn't exist
+        mkdir -p "$CONFIG_DIR"
 
-    # Create new config content in a temp file
-    TEMP_FILE=$(mktemp)
-    ${formatCommand} > "$TEMP_FILE"
+        # Create new config content in a temp file (safely, without shell interpretation)
+        TEMP_FILE=$(mktemp)
+        if ${
+      if isJson && pkgs != null
+      then "true"
+      else "false"
+    }; then
+          # For JSON: use jq to format
+          echo '${content}' | ${
+      if pkgs != null
+      then "${pkgs.jq}/bin/jq '.'"
+      else "cat"
+    } > "$TEMP_FILE"
+        else
+          # For plain text: write content directly to avoid shell interpretation
+          cat > "$TEMP_FILE" << 'NIXEOF'
+    ${content}NIXEOF
+        fi
 
-    # If config exists and is different from new content, create backup and show diff
-    if [ -f "$CONFIG_FILE" ]; then
-      if ! cmp -s "$CONFIG_FILE" "$TEMP_FILE"; then
-        cp "$CONFIG_FILE" "$BACKUP_FILE"
-        echo "" >&2
-        printf "📁 \033[1;36m%s\033[0m config backed up to %s\n" "${name}" "$BACKUP_FILE" >&2
-        printf "🔄 Overwriting manual changes in \033[1;33m%s\033[0m config (%s):\n" "${name}" "$CONFIG_FILE" >&2
-        ${diffCommand} "$CONFIG_FILE" "$TEMP_FILE" >&2 || true
-        echo "" >&2
-      fi
-    fi
+        # If config exists and is different from new content, create backup and show diff
+        if [ -f "$CONFIG_FILE" ]; then
+          if ! cmp -s "$CONFIG_FILE" "$TEMP_FILE"; then
+            cp "$CONFIG_FILE" "$BACKUP_FILE"
+            echo "" >&2
+            printf "📁 \033[1;36m%s\033[0m config backed up to %s\n" "${name}" "$BACKUP_FILE" >&2
+            printf "🔄 Overwriting manual changes in \033[1;33m%s\033[0m config (%s):\n" "${name}" "$CONFIG_FILE" >&2
+            ${diffCommand} "$CONFIG_FILE" "$TEMP_FILE" >&2 || true
+            echo "" >&2
+          fi
+        fi
 
-    # Always overwrite with new config
-    cp "$TEMP_FILE" "$CONFIG_FILE"
-    rm "$TEMP_FILE"
+        # Always overwrite with new config
+        cp "$TEMP_FILE" "$CONFIG_FILE"
+        rm "$TEMP_FILE"
 
-    # Make sure it's writable
-    chmod 644 "$CONFIG_FILE"
+        # Make sure it's writable
+        chmod 644 "$CONFIG_FILE"
 
   '';
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -38,59 +38,61 @@
     configFile = builtins.baseNameOf configPath;
     backupFile = "${configDir}/${configFile}.home-manager.backup";
 
+    shouldFormatJson = isJson && pkgs != null;
+
     # Use delta if available, fallback to diff
     diffCommand =
       if pkgs != null
       then "${pkgs.delta}/bin/delta --file-style=omit --hunk-header-style=omit"
       else "diff -u";
   in ''
-        CONFIG_DIR="${configDir}"
-        CONFIG_FILE="${configPath}"
-        BACKUP_FILE="${backupFile}"
+            CONFIG_DIR="${configDir}"
+            CONFIG_FILE="${configPath}"
+            BACKUP_FILE="${backupFile}"
 
-        # Create directory if it doesn't exist
-        mkdir -p "$CONFIG_DIR"
+            # Create directory if it doesn't exist
+            mkdir -p "$CONFIG_DIR"
 
-        # Create new config content in a temp file (safely, without shell interpretation)
-        TEMP_FILE=$(mktemp)
-        if ${
-      if isJson && pkgs != null
+            # Create new config content in a temp file (safely, without shell interpretation)
+            TEMP_FILE=$(mktemp)
+            if ${
+      if shouldFormatJson
       then "true"
       else "false"
     }; then
-          # For JSON: use jq to format
-          cat <<'NIXEOF' | ${
+              # For JSON: use jq to format
+              cat <<'NIXEOF' | ${
       if pkgs != null
       then "${pkgs.jq}/bin/jq '.'"
       else "cat"
     } > "$TEMP_FILE"
-${content}
-NIXEOF
-        else
-          # For plain text: write content directly to avoid shell interpretation
-          cat > "$TEMP_FILE" << 'NIXEOF'
     ${content}
-NIXEOF
-        fi
+    NIXEOF
+            else
+              # For plain text: write content directly to avoid shell interpretation
+              cat > "$TEMP_FILE" << 'NIXEOF'
+        ${content}
+    NIXEOF
+            fi
 
-        # If config exists and is different from new content, create backup and show diff
-        if [ -f "$CONFIG_FILE" ]; then
-          if ! cmp -s "$CONFIG_FILE" "$TEMP_FILE"; then
-            cp "$CONFIG_FILE" "$BACKUP_FILE"
-            echo "" >&2
-            printf "📁 \033[1;36m%s\033[0m config backed up to %s\n" "${name}" "$BACKUP_FILE" >&2
-            printf "🔄 Overwriting manual changes in \033[1;33m%s\033[0m config (%s):\n" "${name}" "$CONFIG_FILE" >&2
-            ${diffCommand} "$CONFIG_FILE" "$TEMP_FILE" >&2 || true
-            echo "" >&2
-          fi
-        fi
+            # If config exists and is different from new content, create backup and show diff
+            if [ -f "$CONFIG_FILE" ]; then
+              if ! cmp -s "$CONFIG_FILE" "$TEMP_FILE"; then
+                cp "$CONFIG_FILE" "$BACKUP_FILE"
+                echo "" >&2
+                printf "📁 \033[1;36m%s\033[0m config backed up to %s\n" "${name}" "$BACKUP_FILE" >&2
+                printf "🔄 Overwriting manual changes in \033[1;33m%s\033[0m config (%s):\n" "${name}" "$CONFIG_FILE" >&2
+                ${diffCommand} "$CONFIG_FILE" "$TEMP_FILE" >&2 || true
+                echo "" >&2
+              fi
+            fi
 
-        # Always overwrite with new config
-        cp "$TEMP_FILE" "$CONFIG_FILE"
-        rm "$TEMP_FILE"
+            # Always overwrite with new config
+            cp "$TEMP_FILE" "$CONFIG_FILE"
+            rm "$TEMP_FILE"
 
-        # Make sure it's writable
-        chmod 644 "$CONFIG_FILE"
+            # Make sure it's writable
+            chmod 644 "$CONFIG_FILE"
 
   '';
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -18,4 +18,69 @@
             )
         )
         (builtins.readDir path)));
+
+  # Creates an editable config file with backup functionality
+  # Usage: mkEditableConfig {
+  #   name = "myapp";
+  #   configPath = "$HOME/.config/myapp/config";
+  #   content = "config content here";
+  #   pkgs = pkgs; # recommended for delta diffs and jq formatting
+  #   isJson = false; # optional, formats with jq if true
+  # }
+  mkEditableConfig = {
+    name,
+    configPath,
+    content,
+    pkgs ? null,
+    isJson ? false,
+  }: let
+    configDir = builtins.dirOf configPath;
+    configFile = builtins.baseNameOf configPath;
+    backupFile = "${configDir}/${configFile}.home-manager.backup";
+
+    # Escape content for safe shell usage
+    escapedContent = builtins.replaceStrings ["'"] ["'\"'\"'"] content;
+
+    formatCommand =
+      if isJson && pkgs != null
+      then "echo '${content}' | ${pkgs.jq}/bin/jq '.'"
+      else "printf '%s' '${escapedContent}'";
+
+    # Use delta if available, fallback to diff
+    diffCommand =
+      if pkgs != null
+      then "${pkgs.delta}/bin/delta --file-style=omit --hunk-header-style=omit"
+      else "diff -u";
+  in ''
+    CONFIG_DIR="${configDir}"
+    CONFIG_FILE="${configPath}"
+    BACKUP_FILE="${backupFile}"
+
+    # Create directory if it doesn't exist
+    mkdir -p "$CONFIG_DIR"
+
+    # Create new config content in a temp file
+    TEMP_FILE=$(mktemp)
+    ${formatCommand} > "$TEMP_FILE"
+
+    # If config exists and is different from new content, create backup and show diff
+    if [ -f "$CONFIG_FILE" ]; then
+      if ! cmp -s "$CONFIG_FILE" "$TEMP_FILE"; then
+        cp "$CONFIG_FILE" "$BACKUP_FILE"
+        echo "" >&2
+        printf "📁 \033[1;36m%s\033[0m config backed up to %s\n" "${name}" "$BACKUP_FILE" >&2
+        printf "🔄 Overwriting manual changes in \033[1;33m%s\033[0m config (%s):\n" "${name}" "$CONFIG_FILE" >&2
+        ${diffCommand} "$CONFIG_FILE" "$TEMP_FILE" >&2 || true
+        echo "" >&2
+      fi
+    fi
+
+    # Always overwrite with new config
+    cp "$TEMP_FILE" "$CONFIG_FILE"
+    rm "$TEMP_FILE"
+
+    # Make sure it's writable
+    chmod 644 "$CONFIG_FILE"
+
+  '';
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -67,7 +67,8 @@
         else
           # For plain text: write content directly to avoid shell interpretation
           cat > "$TEMP_FILE" << 'NIXEOF'
-    ${content}NIXEOF
+    ${content}
+NIXEOF
         fi
 
         # If config exists and is different from new content, create backup and show diff

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -38,11 +38,6 @@
     configFile = builtins.baseNameOf configPath;
     backupFile = "${configDir}/${configFile}.home-manager.backup";
 
-    formatCommand =
-      if isJson && pkgs != null
-      then "echo '${content}' | ${pkgs.jq}/bin/jq '.'"
-      else "cat";
-
     # Use delta if available, fallback to diff
     diffCommand =
       if pkgs != null


### PR DESCRIPTION
## ✨ Add editable config system with diff visualization

### What this does:
- **📁 Editable configs**: Creates real files (not symlinks) that can be manually edited
- **🔄 Smart backups**: Auto-backs up manual changes with `.home-manager.backup` suffix
- **🎨 Beautiful diffs**: Shows what's being overwritten using delta with colors
- **🔇 Clean output**: Silent when no changes, detailed when overwriting

### Implementation:
- Created reusable `mylib.mkEditableConfig` function in `lib/default.nix`
- Migrated Ghostty and Cursor configs to use the shared system
- Added colored output with proper visual spacing

### Usage:
```nix
home.activation.myAppConfig = mylib.mkEditableConfig {
  name = "MyApp";
  configPath = "$HOME/.config/myapp/config";
  content = "config content";
  pkgs = pkgs; # for delta diffs
};
```

Now you can manually edit configs and see exactly what changes are overwritten when running `just home`! 🎯